### PR TITLE
Support for Mailable Classes and for web.php routes

### DIFF
--- a/src/Finder.ts
+++ b/src/Finder.ts
@@ -116,6 +116,8 @@ export class Finder {
 			/\$view\s*=\s*(['"])([^'"]*)\1/,
 			/View::exists\(\s*(['"])([^'"]*)\1/,
 			/View::first[^'"]*(['"])([^'"]*)\1/,
+			/view:\s*(['"])([^'"]*)\1/,
+            /view\(\s*['"][^'"]*['"],\s*(['"])([^'"]*)\1/,
 		];
 
 		const trasformFilename = (place: Place) => {


### PR DESCRIPTION
two line change 

Line 119 on Finder.ts: `/view:\s*(['"])([^'"]*)\1/,` will support Mailable Classes | string that matches is `view: 'emails.internal.password-reset'`

Line 120 on Finder.ts: `/view\(\s*['"][^'"]*['"],\s*(['"])([^'"]*)\1/,` will support routes inside routes/web.php | string that matches is view('/anytext/here', 'pages.public.auth.login')