### PR TITLE
Fix double "/" in path of Controller

### DIFF
--- a/src/Finder.ts
+++ b/src/Finder.ts
@@ -217,7 +217,7 @@ export class Finder {
 		place = ctx.setControllerNamespace(blocks, place);
 
 		place.path = place.path
-			.replace('::class', '')
+			.replace('::class', '').replace(/\\\\/g, '\\')
 			.replace(/\\/g, '/') + '.php';
 
 		return place;


### PR DESCRIPTION
Hi @absszero , thank for your great extension.

I would like to provide a solution for an issue: double "/" in the path of Controller
And hope that you will review for other path too, or find out better solution.

Version I use:
- MS Window 11
- VSCode v.1.85.1
- Ext. v.4.26.0

Issue capture:
![image](https://github.com/absszero/vscode-laravel-goto/assets/14900191/0eb33eec-cd36-4875-b482-efde04795e45)

Fix result:
![image](https://github.com/absszero/vscode-laravel-goto/assets/14900191/f0cd1df9-a387-4839-ae42-0a7a625339b1)
